### PR TITLE
Adds functionality and fixes issues with failed jobs list

### DIFF
--- a/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss.erb
+++ b/app/assets/stylesheets/resque_web/bootstrap_and_overrides.css.scss.erb
@@ -123,9 +123,9 @@ body {
 .container ul.failed li dl dt {font-size:80%; color:#999; width:60px; float:left; padding-top:1px; text-align:right;}
 .container ul.failed li dl dd {margin-bottom:10px; margin-left:70px;}
 .container ul.failed li dl dd .retried { float:right; text-align: right; }
-.container ul.failed li dl dd .retried .remove { display:none; margin-top: 8px; }
+.container ul.failed li dl dd .retried .remove { margin-top: 8px; }
 .container ul.failed li.hover dl dd .retried .remove { display:block; }
-.container ul.failed li dl dd .controls { display:none; float:right; }
+.container ul.failed li dl dd .controls { float:right; }
 .container ul.failed li.hover dl dd .controls { display:block; }
 .container ul.failed li dl dd code, .container ul.failed li dl dd pre { font-family:Monaco, "Courier New", monospace; font-size:90%; white-space: pre-wrap;}
 .container ul.failed li dl dd.error a {font-family:Monaco, "Courier New", monospace; font-size:90%; }

--- a/app/controllers/resque_web/failures_controller.rb
+++ b/app/controllers/resque_web/failures_controller.rb
@@ -38,6 +38,24 @@ module ResqueWeb
       redirect_to failures_path(redirect_params)
     end
 
+    def retry_all_for_exception
+      if params[:exception].present?
+        exception = params[:exception]
+        job_ids = []
+
+        Resque::Failure.each(0, Resque::Failure.count, params[:queue] || 'failed') do |id, item|
+          if item['exception'] == exception
+            job_ids << id
+          end
+        end
+
+        job_ids.reverse.map { |id| reque_single_job(id) }
+      else
+        flash[:error] = "No exception specified for retrying failures."
+      end
+      redirect_to failures_path(redirect_params)
+    end
+
     private
 
     #API agnostic for Resque 2 with duck typing on requeue_and_remove

--- a/app/controllers/resque_web/failures_controller.rb
+++ b/app/controllers/resque_web/failures_controller.rb
@@ -49,7 +49,7 @@ module ResqueWeb
           end
         end
 
-        job_ids.reverse.map { |id| reque_single_job(id) }
+        job_ids.sort.reverse.map { |id| reque_single_job(id) }
       else
         flash[:error] = "No exception specified for retrying failures."
       end

--- a/app/helpers/resque_web/application_helper.rb
+++ b/app/helpers/resque_web/application_helper.rb
@@ -43,6 +43,7 @@ module ResqueWeb
       start    = options[:start] || 1
       per_page = options[:per_page] || PER_PAGE
       total    = options[:total] || 0
+      span_tag = options[:span_tag]
       return if total < per_page
 
       markup = ""
@@ -54,7 +55,7 @@ module ResqueWeb
         markup << link_to(raw("more &raquo;"), params.permit!.merge(:start => start + per_page), :class => 'btn more')
       end
 
-      content_tag :p, raw(markup), :class => 'pagination'
+      content_tag (span_tag ? :span : :p), raw(markup), :class => (span_tag ? '' : 'pagination')
     end
 
     def poll(polling=false)

--- a/app/helpers/resque_web/failures_helper.rb
+++ b/app/helpers/resque_web/failures_helper.rb
@@ -1,7 +1,7 @@
 module ResqueWeb
   module FailuresHelper
     def each_failure(&block)
-      Resque::Failure.each(failure_start_at, failure_per_page, params[:queue], params[:class], &block)
+      Resque::Failure.each(failure_start_at, failure_per_page, params[:queue], params[:class], 'asc', &block)
     end
 
     def failure_date_format

--- a/app/views/resque_web/failures/_failed_job.html.erb
+++ b/app/views/resque_web/failures/_failed_job.html.erb
@@ -38,7 +38,7 @@
     <dt>Exception</dt>
     <dd>
       <code><%= job['exception'] %></code>
-      <%= form_tag(retry_all_for_exception_failures_path(exception: job['exception'].to_s), method: :put) do %>
+      <%= form_tag(retry_all_for_exception_failures_path(exception: job['exception'].to_s), method: :put, style: 'margin-top: 0;') do %>
         <%= submit_tag "Retry All Jobs with Exception", data: { confirm: "Are you sure you want to retry ALL #{failure_queue_name.downcase} jobs with this exception?" } %>
       <% end %>
     </dd>

--- a/app/views/resque_web/failures/_failed_job.html.erb
+++ b/app/views/resque_web/failures/_failed_job.html.erb
@@ -7,7 +7,7 @@
     <dt>Worker</dt>
     <dd>
       <%= job['worker'].split(':')[0...2].join(':') %>
-      on <b class="label label-info"><%= job['queue'] %></b >
+      on <b class="label label-info"><%= job['queue'] %></b>
       at <b><span class="time"><%= Time.parse(job['failed_at']).strftime(failure_date_format) %></span></b>
 
       <% if job['retried_at'] %>
@@ -36,7 +36,12 @@
     <dt>Arguments</dt>
     <dd><pre><%= job_arguments(job) %></pre></dd>
     <dt>Exception</dt>
-    <dd><code><%= job['exception'] %></code></dd>
+    <dd>
+      <code><%= job['exception'] %></code>
+      <%= form_tag(retry_all_for_exception_failures_path(exception: job['exception'].to_s), method: :put) do %>
+        <%= submit_tag "Retry All Jobs with Exception", data: { confirm: "Are you sure you want to retry ALL #{failure_queue_name.downcase} jobs with this exception?" } %>
+      <% end %>
+    </dd>
     <dt>Error</dt>
     <dd class="error">
       <% if job['backtrace'] %>

--- a/app/views/resque_web/failures/index.html.erb
+++ b/app/views/resque_web/failures/index.html.erb
@@ -8,6 +8,7 @@
   <%= form_tag(destroy_all_failures_path(queue: params[:queue]), method: :delete) do %>
     <%= submit_tag "Clear #{failure_queue_name} Jobs", class: 'btn btn-danger', data: { confirm: "Are you sure you want to clear ALL #{failure_queue_name.downcase} jobs?" } %>
     <% if failure_size > failure_per_page %>
+      <%= pagination(start: failure_start_at, total: failure_size) unless params[:class] %>
       <%= link_to "Last page &raquo;".html_safe, { start: (failure_size - failure_per_page) }, class: 'btn' %>
     <% end %>
   <% end %>
@@ -17,7 +18,7 @@
 <% end %>
 
 <% if multiple_failure_queues? && !params[:queue] %>
-  <p class="sub"><b><%= Resque::Failure.queues.size %></b> failure queues total</sub>
+  <p class="sub"><b><%= Resque::Failure.queues.size %></b> failure queues total</p>
   <%= render partial: 'overview' %>
 <% else %>
   <p class="sub">Showing <%= failure_start_at %> to <%= failure_end_at %> of <b><%= failure_size %></b> jobs</p>

--- a/app/views/resque_web/failures/index.html.erb
+++ b/app/views/resque_web/failures/index.html.erb
@@ -8,7 +8,7 @@
   <%= form_tag(destroy_all_failures_path(queue: params[:queue]), method: :delete) do %>
     <%= submit_tag "Clear #{failure_queue_name} Jobs", class: 'btn btn-danger', data: { confirm: "Are you sure you want to clear ALL #{failure_queue_name.downcase} jobs?" } %>
     <% if failure_size > failure_per_page %>
-      <%= pagination(start: failure_start_at, total: failure_size) unless params[:class] %>
+      <%= pagination(start: failure_start_at, total: failure_size, span_tag: true) unless params[:class] %>
       <%= link_to "Last page &raquo;".html_safe, { start: (failure_size - failure_per_page) }, class: 'btn' %>
     <% end %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ ResqueWeb::Engine.routes.draw do
     end
     collection do
       put 'retry_all'
+      put 'retry_all_for_exception'
       delete 'destroy_all'
     end
   end


### PR DESCRIPTION
This PR: 
* Ensures "Retry or Remove" links are always present for all failed jobs, not only when a job is hovered over. This fixes a bug whereby one must wait for the entire page to load and JS to initialize to use these important actions. 
* If backend is capable of it (I don't think our backend is, sadly) reorders failures to show the newest first instead of oldest first.
* Adds pagination buttons to the top of the failed jobs list, removing the need to scroll all the way to the bottom if the user knows from page load that they want to go to the previous or next page. Pagination is still present at the bottom. 
* Importantly, adds a button to each failed job, "Retry All Jobs with Exception" with associated controller functionality. This resolves a significant and regular need to retry all failed jobs of a particular exception type, after that exception has been addressed. Prior to this, this had to be done through the Rails console and was time-consuming.

Screenshot of new failed job UI:

<img width="1204" alt="Screenshot 2025-06-17 at 4 27 13 PM" src="https://github.com/user-attachments/assets/2bcc5c16-c7c8-47ac-acae-fa080b8ea441" />

 